### PR TITLE
Changed healthmanager to healthmanager_id during deepscan

### DIFF
--- a/nlbaas2octavia_lb_replicator/manager.py
+++ b/nlbaas2octavia_lb_replicator/manager.py
@@ -37,7 +37,7 @@ class Manager(object):
             pool_id = pool['id']
             lb_pool = self.os_clients.neutronclient.show_lbaas_pool(pool_id)
             self._lb_pools[pool_id] = lb_pool
-            if pool.get('healthmonitor'):
+            if pool.get('healthmonitor_id'):
                 # Health monitor is optional
                 healthmonitor_id = pool['healthmonitor']['id']
                 lb_healthmonitor = (


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/bin/lb-replicator", line 10, in <module>
    sys.exit(main())
  File "/usr/lib/python2.7/site-packages/nlbaas2octavia_lb_replicator/cmd.py", line 32, in main
    lb_replicator.collect_lb_info_from_api()
  File "/usr/lib/python2.7/site-packages/nlbaas2octavia_lb_replicator/manager.py", line 73, in collect_lb_info_from_api
    self._pools_deep_scan(listener['pools'])
  File "/usr/lib/python2.7/site-packages/nlbaas2octavia_lb_replicator/manager.py", line 45, in _pools_deep_scan
    .show_health_monitor(healthmonitor_id)
  File "/usr/lib/python2.7/site-packages/neutronclient/v2_0/client.py", line 1389, in show_health_monitor
    params=_params)
  File "/usr/lib/python2.7/site-packages/neutronclient/v2_0/client.py", line 354, in get
    headers=headers, params=params)
  File "/usr/lib/python2.7/site-packages/neutronclient/v2_0/client.py", line 331, in retry_request
    headers=headers, params=params)
  File "/usr/lib/python2.7/site-packages/neutronclient/v2_0/client.py", line 294, in do_request
    self._handle_fault_response(status_code, replybody, resp)
  File "/usr/lib/python2.7/site-packages/neutronclient/v2_0/client.py", line 269, in _handle_fault_response
    exception_handler_v20(status_code, error_body)
  File "/usr/lib/python2.7/site-packages/neutronclient/v2_0/client.py", line 93, in exception_handler_v20
    request_ids=request_ids)
neutronclient.common.exceptions.NotFound: The resource could not be found.